### PR TITLE
Fixed the reset signal for vivosoc 3

### DIFF
--- a/src/cables/ftdi/ftdi.hpp
+++ b/src/cables/ftdi/ftdi.hpp
@@ -80,6 +80,7 @@ class Ftdi : public Cable {
     };
 
     bool set_bit_value(int bit, int value);
+    bool set_bit_value_del(int bit, int value, int del);
     bool set_bit_direction(int bit, int isout);
 
     bool bit_out(char outbit, bool tms);


### PR DESCRIPTION
@glaserf fixed the reset signal when using the JTAG with VivoSoC 3. Only one reset pulse is now issued. Also, a more deterministic delay was implemented to insure long enough reset time on different environments (virtual machine ubuntu vs native os). 
Please update the versions.cfg accordingly.